### PR TITLE
Add support for "html" and "svg" tag functions

### DIFF
--- a/syntaxes/leet-html.json
+++ b/syntaxes/leet-html.json
@@ -108,7 +108,6 @@
       ]
     },
 
-       
     {
       "begin": "(\\?|\\:)\\s*(`)",
       "beginCaptures": {
@@ -135,6 +134,32 @@
         }
       },
       "end": "(`)",
+      "patterns": [
+        {
+          "include": "source.ts#template-substitution-element"
+        },
+        {
+          "include": "text.html.basic"
+        }
+      ]
+    },
+
+    {
+      "begin": "(?:^|\\s|\\.)(h(?:tm[lx]?)?)(?:\\([^)]*\\))?(`)",
+      "beginCaptures": {
+				"1": {
+					"name": "entity.name.function.tagged-template.ts"
+        },
+        "2": {
+					"name": "punctuation.definition.string.template.begin.ts"
+        }
+      },
+      "end": "(`)",
+      "endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.template.end.ts"
+        }
+      },
       "patterns": [
         {
           "include": "source.ts#template-substitution-element"

--- a/syntaxes/leet-html.json
+++ b/syntaxes/leet-html.json
@@ -145,19 +145,19 @@
     },
 
     {
-      "begin": "(?:^|\\s|\\.)(h(?:tm[lx]?)?)(?:\\([^)]*\\))?(`)",
+      "begin": "(?:^|\\s|\\.)(h(?:tm[lx]?)?|s(?:vg)?)(?:\\([^)]*\\))?(`)",
       "beginCaptures": {
-				"1": {
-					"name": "entity.name.function.tagged-template.ts"
+        "1": {
+          "name": "entity.name.function.tagged-template.ts"
         },
         "2": {
-					"name": "punctuation.definition.string.template.begin.ts"
+          "name": "punctuation.definition.string.template.begin.ts"
         }
       },
       "end": "(`)",
       "endCaptures": {
-				"1": {
-					"name": "punctuation.definition.string.template.end.ts"
+        "1": {
+          "name": "punctuation.definition.string.template.end.ts"
         }
       },
       "patterns": [


### PR DESCRIPTION
I added [tagged templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) support for functions with the following names:

- html
- htmx
- htm
- h
- svg
- s

This is for libs like [lit-html](https://github.com/lit/lit/tree/main/packages/lit-html) that make use of js code like `` html`<div>Hello ${name}!</div>` `` and also for tag functions that return another tag function like `` html(arg1, arg2, argN)`<div>Hello ${name}!</div>` ``